### PR TITLE
feat(blog): add social media share links

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -122,3 +122,55 @@ a.tag:hover,
   color: var(--color-secondary);
   background: var(--color-secondary-dim);
 }
+
+/* Share Links */
+.share {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.share__label {
+  font-family: "DejaVu Sans", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-faint);
+}
+
+.share__links {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.share__links a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  background: var(--color-bg-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-faint);
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.share__links svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.share__links a:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-dim);
+  border-color: var(--color-accent);
+}

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -12,5 +12,25 @@
     <div class="prose">
         {{.Post.Content}}
     </div>
+    <footer class="share">
+        <span class="share__label">Share</span>
+        <div class="share__links">
+            <a href="https://x.com/intent/tweet?text={{urlquery .Post.Title}}&url={{urlquery .CanonicalURL}}" target="_blank" rel="noopener noreferrer" aria-label="Share on X">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href="https://www.facebook.com/sharer/sharer.php?u={{urlquery .CanonicalURL}}" target="_blank" rel="noopener noreferrer" aria-label="Share on Facebook">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>
+            </a>
+            <a href="https://www.linkedin.com/sharing/share-offsite/?url={{urlquery .CanonicalURL}}" target="_blank" rel="noopener noreferrer" aria-label="Share on LinkedIn">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+            </a>
+            <a href="https://reddit.com/submit?url={{urlquery .CanonicalURL}}&title={{urlquery .Post.Title}}" target="_blank" rel="noopener noreferrer" aria-label="Share on Reddit">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>
+            </a>
+            <a href="mailto:?subject={{urlquery .Post.Title}}&body={{urlquery .CanonicalURL}}" aria-label="Share via email">
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor"><path d="M1.5 8.67v8.58a3 3 0 0 0 3 3h15a3 3 0 0 0 3-3V8.67l-8.928 5.493a3 3 0 0 1-3.144 0L1.5 8.67z"/><path d="M22.5 6.908V6.75a3 3 0 0 0-3-3h-15a3 3 0 0 0-3 3v.158l9.714 5.978a1.5 1.5 0 0 0 1.572 0L22.5 6.908z"/></svg>
+            </a>
+        </div>
+    </footer>
 </article>
 {{end}}


### PR DESCRIPTION
## Summary

- Add share buttons (X, Facebook, LinkedIn, Reddit, Email) to blog post footers using inline SVGs
- Style with existing design tokens (border, accent colors, rounded buttons with hover states)
- Use LinkedIn's current `share-offsite` API and `urlquery` template function for proper URL encoding

## Test plan

- [x] `go test ./...` passes
- [x] No third-party CDN dependencies (inline SVGs, CSP-compatible)
- [ ] Verify 5 share icons render correctly on a blog post
- [ ] Verify hover states (teal accent color + accent-dim background)
- [ ] Click each share link to verify correct platform URL with pre-filled title/URL
- [ ] Test email share link opens mailto with subject and body