### PR TITLE
feat(particles): add WF letter formation animation

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -31,6 +31,7 @@ type PageData struct {
 	JSONLD       template.HTML
 	ActiveNav    string
 	Particles    config.ParticleConfig
+	Formation    string
 }
 
 func (d *Deps) basePage(activeNav string) PageData {

--- a/internal/handler/home.go
+++ b/internal/handler/home.go
@@ -25,6 +25,7 @@ func (d *Deps) Home() http.HandlerFunc {
 		data.CanonicalURL = d.SiteURL
 		data.Description = "Personal website of William Findlay — software engineer, security researcher, and systems thinker."
 		data.JSONLD = buildHomeJSONLD(d.SiteTitle, d.SiteURL)
+		data.Formation = "WF"
 
 		if store != nil {
 			limit := 5

--- a/static/js/particles.js
+++ b/static/js/particles.js
@@ -36,13 +36,42 @@
     colorAlt: attrColor("colorAlt", { r: 128, g: 90, b: 213 }),
   };
 
+  // Formation
+  const FORMATION_TEXT = canvas.dataset.formation || "";
+  const PHASE = { IDLE: 0, GATHERING: 1, HOLDING: 2, RELEASING: 3 };
+  const GATHER_MS = 2000;
+  const HOLD_MS = 1500;
+  const RELEASE_MS = 3000;
+  let formationPhase = PHASE.IDLE;
+  let formationStart = 0;
+  let formationCount = 0;
+
   let width, height, dpr;
   let wrapW, wrapH;
   let mouse = { x: -1000, y: -1000 };
   let particles = [];
   let animId;
 
+  function cancelFormation() {
+    if (formationPhase === PHASE.IDLE) return;
+    formationPhase = PHASE.IDLE;
+    formationCount = 0;
+    for (let i = 0; i < particles.length; i++) {
+      const p = particles[i];
+      p.isFormation = false;
+      p.targetX = undefined;
+      p.targetY = undefined;
+      p.originX = undefined;
+      p.originY = undefined;
+      p.releaseX = undefined;
+      p.releaseY = undefined;
+      p.formationNeighbors = undefined;
+    }
+  }
+
   function resize() {
+    cancelFormation();
+
     dpr = Math.min(window.devicePixelRatio || 1, 2);
     width = window.innerWidth;
     height = window.innerHeight;
@@ -103,7 +132,138 @@
     }
   }
 
-  function update() {
+  // --- Formation logic ---
+
+  function sampleTextPoints(text, fontSize) {
+    const off = document.createElement("canvas");
+    const offCtx = off.getContext("2d");
+    const font = `bold ${fontSize}px "DejaVu Sans", sans-serif`;
+    offCtx.font = font;
+    const metrics = offCtx.measureText(text);
+
+    const tw = Math.ceil(metrics.width);
+    const th = Math.ceil(fontSize * 1.4);
+    off.width = tw;
+    off.height = th;
+
+    offCtx.font = font;
+    offCtx.fillStyle = "#fff";
+    offCtx.textBaseline = "middle";
+    offCtx.fillText(text, 0, th / 2);
+
+    const data = offCtx.getImageData(0, 0, tw, th).data;
+    const points = [];
+    const step = Math.max(3, Math.round(fontSize / 40));
+
+    for (let y = 0; y < th; y += step) {
+      for (let x = 0; x < tw; x += step) {
+        if (data[(y * tw + x) * 4 + 3] > 128) {
+          points.push({ x: x - tw / 2, y: y - th / 2 });
+        }
+      }
+    }
+
+    return points;
+  }
+
+  function easeOutCubic(t) {
+    return 1 - (1 - t) * (1 - t) * (1 - t);
+  }
+
+  function initFormation() {
+    if (reducedMotion || width < 768 || !FORMATION_TEXT) return;
+
+    const fontSize = Math.min(width * 0.08, 130);
+    const points = sampleTextPoints(FORMATION_TEXT, fontSize);
+
+    const targetCount = Math.min(
+      Math.floor(particles.length * 0.7),
+      85,
+      points.length,
+    );
+
+    // Stride selection: pick every Nth point for even spatial distribution
+    const stride = Math.max(1, Math.floor(points.length / targetCount));
+    const selected = [];
+    for (let i = 0; i < points.length && selected.length < targetCount; i += stride) {
+      selected.push(points[i]);
+    }
+    if (selected.length < 25) return;
+
+    // Anchor WF relative to the hero title
+    let cx, cy;
+    const titleEl = document.querySelector(".hero__title");
+    if (titleEl) {
+      const rect = titleEl.getBoundingClientRect();
+      if (width >= 768) {
+        // Desktop: to the right of the title
+        cx = rect.right + 60;
+        cy = rect.top + rect.height / 2;
+      } else {
+        // Mobile: centered behind the title
+        cx = rect.left + rect.width / 2;
+        cy = rect.top + rect.height / 2;
+      }
+    } else {
+      cx = width * 0.72;
+      cy = height * 0.28;
+    }
+
+    formationCount = selected.length;
+    for (let i = 0; i < selected.length; i++) {
+      const p = particles[i];
+      p.originX = p.x;
+      p.originY = p.y;
+      p.targetX = cx + selected[i].x;
+      p.targetY = cy + selected[i].y;
+      p.isFormation = true;
+    }
+
+    // Precompute 3 nearest neighbors by target position for mesh connections
+    for (let i = 0; i < formationCount; i++) {
+      const pi = particles[i];
+      const neighbors = [];
+      for (let j = 0; j < formationCount; j++) {
+        if (i === j) continue;
+        const dx = pi.targetX - particles[j].targetX;
+        const dy = pi.targetY - particles[j].targetY;
+        neighbors.push({ idx: j, d: dx * dx + dy * dy });
+      }
+      neighbors.sort((a, b) => a.d - b.d);
+      pi.formationNeighbors = [neighbors[0].idx, neighbors[1].idx, neighbors[2].idx];
+    }
+
+    formationPhase = PHASE.GATHERING;
+    formationStart = performance.now();
+  }
+
+  // --- End formation logic ---
+
+  function update(now) {
+    // Formation phase transitions
+    if (formationPhase === PHASE.GATHERING) {
+      if (now - formationStart >= GATHER_MS) {
+        formationPhase = PHASE.HOLDING;
+        formationStart = now;
+      }
+    } else if (formationPhase === PHASE.HOLDING) {
+      if (now - formationStart >= HOLD_MS) {
+        formationPhase = PHASE.RELEASING;
+        formationStart = now;
+        for (let i = 0; i < particles.length; i++) {
+          const p = particles[i];
+          if (p.isFormation) {
+            p.releaseX = p.x;
+            p.releaseY = p.y;
+          }
+        }
+      }
+    } else if (formationPhase === PHASE.RELEASING) {
+      if (now - formationStart >= RELEASE_MS) {
+        cancelFormation();
+      }
+    }
+
     for (let i = 0; i < particles.length; i++) {
       const p = particles[i];
 
@@ -113,7 +273,35 @@
       p.radius = p.baseRadius + pulse * 0.5;
       p.opacity = 0.3 + pulse * 0.15;
 
-      // Mouse repulsion
+      // Formation: gathering
+      if (p.isFormation && formationPhase === PHASE.GATHERING) {
+        const t = easeOutCubic(
+          Math.min((now - formationStart) / GATHER_MS, 1),
+        );
+        p.x = p.originX + (p.targetX - p.originX) * t;
+        p.y = p.originY + (p.targetY - p.originY) * t;
+        continue;
+      }
+
+      // Formation: holding (Lissajous jitter)
+      if (p.isFormation && formationPhase === PHASE.HOLDING) {
+        const jitter = 1.5;
+        p.x = p.targetX + Math.sin(p.pulsePhase * 1.3) * jitter;
+        p.y = p.targetY + Math.cos(p.pulsePhase * 0.9) * jitter;
+        continue;
+      }
+
+      // Formation: releasing (ease back to origin)
+      if (p.isFormation && formationPhase === PHASE.RELEASING) {
+        const t = easeOutCubic(
+          Math.min((now - formationStart) / RELEASE_MS, 1),
+        );
+        p.x = p.releaseX + (p.originX - p.releaseX) * t;
+        p.y = p.releaseY + (p.originY - p.releaseY) * t;
+        continue;
+      }
+
+      // Normal physics (IDLE or non-formation particles)
       const dx = p.x - mouse.x;
       const dy = p.y - mouse.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
@@ -123,15 +311,12 @@
         p.vy += (dy / dist) * force;
       }
 
-      // Drift
       p.x += p.vx;
       p.y += p.vy;
 
-      // Damping
       p.vx *= 0.998;
       p.vy *= 0.998;
 
-      // Wrap around edges (fixed bounds so zoom doesn't cluster)
       if (p.x < -10) p.x = wrapW + 10;
       if (p.x > wrapW + 10) p.x = -10;
       if (p.y < -10) p.y = wrapH + 10;
@@ -144,23 +329,56 @@
 
     // Connection lines
     if (!reducedMotion) {
+      const formationActive =
+        formationPhase === PHASE.GATHERING || formationPhase === PHASE.HOLDING;
+      const maxDist = CONFIG.connectionDistance;
+
+      // Distance-based connections (skip both-formation pairs during formation)
       for (let i = 0; i < particles.length; i++) {
         for (let j = i + 1; j < particles.length; j++) {
           const a = particles[i];
           const b = particles[j];
+
+          if (formationActive && a.isFormation && b.isFormation) continue;
+
           const dx = a.x - b.x;
           const dy = a.y - b.y;
           const dist = Math.sqrt(dx * dx + dy * dy);
 
-          if (dist < CONFIG.connectionDistance) {
+          if (dist < maxDist) {
             const opacity =
-              (1 - dist / CONFIG.connectionDistance) * CONFIG.connectionOpacity;
+              (1 - dist / maxDist) * CONFIG.connectionOpacity;
             ctx.beginPath();
             ctx.moveTo(a.x, a.y);
             ctx.lineTo(b.x, b.y);
             ctx.strokeStyle = `rgba(${CONFIG.color.r}, ${CONFIG.color.g}, ${CONFIG.color.b}, ${opacity})`;
             ctx.lineWidth = 0.5;
             ctx.stroke();
+          }
+        }
+      }
+
+      // Nearest-neighbor connections between formation particles (distance-capped)
+      if (formationActive && formationCount > 1) {
+        const { r, g, b } = CONFIG.color;
+        ctx.lineWidth = 0.8;
+        for (let i = 0; i < formationCount; i++) {
+          const a = particles[i];
+          if (!a.formationNeighbors) continue;
+          for (const j of a.formationNeighbors) {
+            if (j < i) continue; // each line drawn once
+            const nb = particles[j];
+            const dx = a.x - nb.x;
+            const dy = a.y - nb.y;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < maxDist) {
+              const opacity = (1 - dist / maxDist) * 0.25;
+              ctx.beginPath();
+              ctx.moveTo(a.x, a.y);
+              ctx.lineTo(nb.x, nb.y);
+              ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, ${opacity})`;
+              ctx.stroke();
+            }
           }
         }
       }
@@ -176,9 +394,9 @@
     }
   }
 
-  function loop() {
+  function loop(now) {
     if (!reducedMotion) {
-      update();
+      update(now);
     }
     draw();
     animId = requestAnimationFrame(loop);
@@ -234,5 +452,10 @@
 
   // Start
   init();
-  loop();
+  if (FORMATION_TEXT) {
+    document.fonts.ready.then(() => {
+      setTimeout(initFormation, 500);
+    });
+  }
+  loop(performance.now());
 })();

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,7 @@
       data-pulse-speed="{{.PulseSpeed}}"
       data-color="{{.Color}}"
       data-color-alt="{{.ColorAlt}}"
-      {{- end}}></canvas>
+      {{- end}}{{- if .Formation}} data-formation="{{.Formation}}"{{end}}></canvas>
 
     <header class="site-header">
         <nav class="nav container">


### PR DESCRIPTION
## Summary

- Particles on the homepage gather into "WF" letterforms anchored to the right of the hero title (centered behind it on mobile), hold with subtle Lissajous jitter, then ease back to original positions over 3 seconds
- Formation uses stride-sampled text points with 3-nearest-neighbor mesh connections that fade in based on distance, replacing the blobby distance-based connections
- Adds `Formation` field to `PageData` and `data-formation` attribute on the canvas element, currently set to "WF" on the homepage only

## Test plan

- [x] `go test ./...` passes
- [ ] Verify "WF" formation is clearly readable during hold phase at 1920px width
- [ ] Verify formation triggers and is readable at 768px width
- [ ] Verify formation does NOT trigger below 768px
- [ ] Verify non-homepage pages are unaffected (no formation)
- [ ] Verify particles return smoothly to original positions after release
- [ ] Verify connection lines fade in naturally as particles converge (no sudden switch)