### PR TITLE
feat(blog): add Giscus comment system

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,13 @@ type ParticleConfig struct {
 	ColorAlt        string // "r,g,b"
 }
 
+type GiscusConfig struct {
+	Repo       string
+	RepoID     string
+	Category   string
+	CategoryID string
+}
+
 type Config struct {
 	Port              string
 	ContentRepoURL    string
@@ -33,6 +40,7 @@ type Config struct {
 	SiteURL           string
 	DevMode           bool
 	Particles         ParticleConfig
+	Giscus            GiscusConfig
 }
 
 func Load() (*Config, error) {
@@ -73,6 +81,13 @@ func Load() (*Config, error) {
 			Color:           envOr("PARTICLE_COLOR", "79,209,197"),
 			ColorAlt:        envOr("PARTICLE_COLOR_ALT", "128,90,213"),
 		},
+	}
+
+	cfg.Giscus = GiscusConfig{
+		Repo:       os.Getenv("GISCUS_REPO"),
+		RepoID:     os.Getenv("GISCUS_REPO_ID"),
+		Category:   os.Getenv("GISCUS_CATEGORY"),
+		CategoryID: os.Getenv("GISCUS_CATEGORY_ID"),
 	}
 
 	if cfg.Particles.SizeMax < cfg.Particles.SizeMin {

--- a/internal/handler/blog.go
+++ b/internal/handler/blog.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/willfindlay/williamfindlaycom/internal/config"
 	"github.com/willfindlay/williamfindlaycom/internal/content"
 )
 
@@ -16,7 +17,8 @@ type blogListData struct {
 
 type blogPostData struct {
 	PageData
-	Post *content.BlogPost
+	Post   *content.BlogPost
+	Giscus config.GiscusConfig
 }
 
 func (d *Deps) BlogList() http.HandlerFunc {
@@ -72,7 +74,7 @@ func (d *Deps) BlogPost() http.HandlerFunc {
 			return
 		}
 
-		data := blogPostData{PageData: d.basePage("blog"), Post: post}
+		data := blogPostData{PageData: d.basePage("blog"), Post: post, Giscus: d.Giscus}
 		data.PageTitle = post.Title
 		data.Description = post.Description
 		data.CanonicalURL = d.SiteURL + "/blog/" + slug

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -17,6 +17,7 @@ type Deps struct {
 	SiteTitle string
 	SiteURL   string
 	Particles config.ParticleConfig
+	Giscus    config.GiscusConfig
 }
 
 type PageData struct {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -25,7 +25,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://giscus.app; style-src 'self' 'unsafe-inline' https://giscus.app; img-src 'self' data: https:; frame-src https://giscus.app")
 		next.ServeHTTP(w, r)
 	})
 }
@@ -33,6 +33,9 @@ func securityHeaders(next http.Handler) http.Handler {
 func cacheStatic(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "public, max-age=3600, s-maxage=300")
+		if r.URL.Path == "css/giscus-theme.css" {
+			w.Header().Set("Access-Control-Allow-Origin", "https://giscus.app")
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,6 +36,7 @@ func New(cfg *config.Config, embedded fs.FS) (*Server, error) {
 		SiteTitle: cfg.SiteTitle,
 		SiteURL:   cfg.SiteURL,
 		Particles: cfg.Particles,
+		Giscus:    cfg.Giscus,
 	}
 
 	return &Server{

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -174,3 +174,20 @@ a.tag:hover,
   background: var(--color-accent-dim);
   border-color: var(--color-accent);
 }
+
+/* Comments */
+.comments {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-border);
+}
+
+.comments__heading {
+  font-family: "DejaVu Sans", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-faint);
+  margin-bottom: var(--space-lg);
+}

--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -1,0 +1,120 @@
+/*
+ * Custom Giscus theme for williamfindlay.com
+ * Maps GitHub Primer CSS custom properties to site design tokens.
+ * Loaded cross-origin inside the Giscus iframe via data-theme attribute.
+ */
+
+main {
+  /* Canvas / backgrounds */
+  --color-canvas-default: #0a0e17;
+  --color-canvas-overlay: #151d2e;
+  --color-canvas-inset: #080c14;
+  --color-canvas-subtle: #111827;
+
+  /* Borders */
+  --color-border-default: #1e293b;
+  --color-border-muted: #172033;
+  --color-border-overlay: #2d3f56;
+
+  /* Foreground / text */
+  --color-fg-default: #c8d1dc;
+  --color-fg-muted: #7e8fa3;
+  --color-fg-subtle: #576478;
+
+  /* Neutral */
+  --color-neutral-muted: rgba(100, 116, 139, 0.25);
+
+  /* Accent (teal) */
+  --color-accent-fg: #4fd1c5;
+  --color-accent-emphasis: #38b2ac;
+  --color-accent-muted: rgba(79, 209, 197, 0.35);
+  --color-accent-subtle: rgba(79, 209, 197, 0.12);
+
+  /* Status colors */
+  --color-success-fg: #4fd1c5;
+  --color-attention-fg: #d4a054;
+  --color-attention-muted: rgba(212, 160, 84, 0.35);
+  --color-attention-subtle: rgba(212, 160, 84, 0.12);
+  --color-danger-fg: #e87272;
+  --color-danger-muted: rgba(232, 114, 114, 0.35);
+  --color-danger-subtle: rgba(232, 114, 114, 0.10);
+
+  /* Buttons, default */
+  --color-btn-text: #c8d1dc;
+  --color-btn-bg: #111827;
+  --color-btn-border: #1e293b;
+  --color-btn-shadow: 0 0 transparent;
+  --color-btn-inset-shadow: 0 0 transparent;
+  --color-btn-hover-bg: #1a2332;
+  --color-btn-hover-border: #2d3f56;
+  --color-btn-active-bg: #0f1520;
+  --color-btn-active-border: #2d3f56;
+  --color-btn-selected-bg: #0a0e17;
+
+  /* Buttons, primary (teal) */
+  --color-btn-primary-text: #0a0e17;
+  --color-btn-primary-bg: #4fd1c5;
+  --color-btn-primary-border: rgba(79, 209, 197, 0.4);
+  --color-btn-primary-shadow: 0 0 transparent;
+  --color-btn-primary-inset-shadow: 0 0 transparent;
+  --color-btn-primary-hover-bg: #38b2ac;
+  --color-btn-primary-hover-border: rgba(79, 209, 197, 0.5);
+  --color-btn-primary-selected-bg: #2c9a90;
+  --color-btn-primary-selected-shadow: 0 0 transparent;
+  --color-btn-primary-disabled-text: rgba(10, 14, 23, 0.5);
+  --color-btn-primary-disabled-bg: rgba(79, 209, 197, 0.4);
+  --color-btn-primary-disabled-border: rgba(79, 209, 197, 0.15);
+
+  /* Action list (dropdown items) */
+  --color-action-list-item-default-hover-bg: rgba(94, 118, 148, 0.12);
+
+  /* Segmented control (Write / Preview tabs) */
+  --color-segmented-control-bg: rgba(100, 116, 139, 0.10);
+  --color-segmented-control-button-bg: #0a0e17;
+  --color-segmented-control-button-selected-border: #2d3f56;
+
+  /* Gray scale for reactions, misc */
+  --color-scale-gray-7: #1a2332;
+  --color-scale-gray-8: #111827;
+  --color-scale-gray-9: #0a0e17;
+  --color-scale-blue-8: rgba(79, 209, 197, 0.15);
+
+  /* Reaction buttons */
+  --color-social-reaction-bg-hover: #1a2332;
+  --color-social-reaction-bg-reacted-hover: rgba(79, 209, 197, 0.15);
+
+  /* Shadows */
+  --color-primer-shadow-inset: 0 0 transparent;
+
+  /* Syntax highlighting (Dracula-adjacent, matching site code blocks) */
+  --color-prettylights-syntax-comment: #576478;
+  --color-prettylights-syntax-constant: #bd93f9;
+  --color-prettylights-syntax-entity: #8be9fd;
+  --color-prettylights-syntax-storage-modifier-import: #c8d1dc;
+  --color-prettylights-syntax-entity-tag: #50fa7b;
+  --color-prettylights-syntax-keyword: #ff79c6;
+  --color-prettylights-syntax-string: #f1fa8c;
+  --color-prettylights-syntax-variable: #ffb86c;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #e87272;
+  --color-prettylights-syntax-invalid-illegal-text: #c8d1dc;
+  --color-prettylights-syntax-invalid-illegal-bg: #6b1a1a;
+  --color-prettylights-syntax-carriage-return-text: #c8d1dc;
+  --color-prettylights-syntax-carriage-return-bg: #6b1a1a;
+  --color-prettylights-syntax-string-regexp: #50fa7b;
+  --color-prettylights-syntax-markup-list: #f1fa8c;
+  --color-prettylights-syntax-markup-heading: #4fd1c5;
+  --color-prettylights-syntax-markup-italic: #c8d1dc;
+  --color-prettylights-syntax-markup-bold: #c8d1dc;
+  --color-prettylights-syntax-markup-deleted-text: #ffa0a0;
+  --color-prettylights-syntax-markup-deleted-bg: #3d1010;
+  --color-prettylights-syntax-markup-inserted-text: #7dffb3;
+  --color-prettylights-syntax-markup-inserted-bg: #0a3020;
+  --color-prettylights-syntax-markup-changed-text: #ffcc80;
+  --color-prettylights-syntax-markup-changed-bg: #3d2000;
+  --color-prettylights-syntax-markup-ignored-text: #c8d1dc;
+  --color-prettylights-syntax-markup-ignored-bg: rgba(79, 209, 197, 0.2);
+  --color-prettylights-syntax-meta-diff-range: #bd93f9;
+  --color-prettylights-syntax-brackethighlighter-angle: #576478;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #334155;
+  --color-prettylights-syntax-constant-other-reference-link: #8be9fd;
+}

--- a/static/js/comments.js
+++ b/static/js/comments.js
@@ -1,0 +1,37 @@
+(() => {
+  function initGiscus() {
+    const container = document.querySelector(".giscus-container");
+    if (!container) return;
+
+    // Clean up any previous instance (SPA navigation)
+    const oldFrame = container.querySelector("iframe.giscus-frame");
+    if (oldFrame) oldFrame.remove();
+    const oldScript = document.querySelector("script[src*='giscus.app']");
+    if (oldScript) oldScript.remove();
+
+    const script = document.createElement("script");
+    script.src = "https://giscus.app/client.js";
+    script.setAttribute("data-repo", container.dataset.repo);
+    script.setAttribute("data-repo-id", container.dataset.repoId);
+    script.setAttribute("data-category", container.dataset.category);
+    script.setAttribute("data-category-id", container.dataset.categoryId);
+    script.setAttribute("data-mapping", "pathname");
+    script.setAttribute("data-strict", "0");
+    script.setAttribute("data-reactions-enabled", "1");
+    script.setAttribute("data-emit-metadata", "0");
+    script.setAttribute("data-input-position", "top");
+    script.setAttribute("data-theme", container.dataset.theme);
+    script.setAttribute("data-lang", "en");
+    script.setAttribute("data-loading", "lazy");
+    script.crossOrigin = "anonymous";
+    script.async = true;
+
+    container.appendChild(script);
+  }
+
+  // Initial page load
+  initGiscus();
+
+  // SPA navigation
+  document.addEventListener("spa:navigate", initGiscus);
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -83,5 +83,6 @@
 
     <script src="/static/js/particles.js"></script>
     <script src="/static/js/navigation.js"></script>
+    <script src="/static/js/comments.js" defer></script>
 </body>
 </html>{{end}}

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -32,5 +32,18 @@
             </a>
         </div>
     </footer>
+    {{if .Giscus.Repo}}
+    <section class="comments">
+        <h2 class="comments__heading">Comments</h2>
+        <div class="giscus-container"
+             data-repo="{{.Giscus.Repo}}"
+             data-repo-id="{{.Giscus.RepoID}}"
+             data-category="{{.Giscus.Category}}"
+             data-category-id="{{.Giscus.CategoryID}}"
+             data-theme="{{.SiteURL}}/static/css/giscus-theme.css">
+            <div class="giscus"></div>
+        </div>
+    </section>
+    {{end}}
 </article>
 {{end}}


### PR DESCRIPTION
## Summary

- Add GitHub Discussions-backed comment system (Giscus) to blog posts, configured via `GISCUS_*` env vars (disabled when unset)
- Update CSP to allow giscus.app scripts/styles/frames, add CORS header on theme CSS for cross-origin iframe loading
- Custom dark theme CSS mapping all 84 Primer tokens to the site's design system (teal accent, dark canvas, muted text), with SPA navigation support

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run` clean
- [x] `gofmt -l .` clean
- [ ] Set `GISCUS_*` env vars in deployment config
- [ ] Visit a blog post on production, confirm Giscus iframe loads with custom theme
- [ ] Verify reaction picker popup has solid dark background (not transparent)
- [ ] Navigate between blog posts via SPA, confirm comments reload for each post
- [ ] Visit a non-blog page, confirm no comments section rendered
- [ ] Run without `GISCUS_*` env vars, confirm no comments section appears