### PR TITLE
feat(blog): add Giscus comment system

### DIFF
--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -118,3 +118,19 @@ main {
   --color-prettylights-syntax-sublimelinter-gutter-mark: #334155;
   --color-prettylights-syntax-constant-other-reference-link: #8be9fd;
 }
+
+/* Compact reactions: inline at top instead of centered block */
+.gsc-reactions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0;
+  gap: 0.25rem;
+}
+
+.gsc-reactions-count {
+  display: none;
+}
+
+.gsc-reactions button {
+  padding: 0.125rem 0.375rem;
+}


### PR DESCRIPTION
## Summary

- Add Giscus (GitHub Discussions-backed) comment widget to blog posts with custom dark theme matching the site's design tokens
- Compact reactions layout: emoji buttons display as a right-aligned inline row instead of a centered block, hiding the redundant "N reactions" text
- CORS and CSP headers configured to allow the cross-origin giscus iframe and custom theme CSS

## Test plan

- [ ] Deploy to production and verify comments widget loads on a blog post
- [ ] Confirm reactions appear as a compact row at the top-right (not centered block)
- [ ] Confirm "0 reactions" text is hidden
- [ ] Confirm reaction picker popup still works
- [ ] Confirm comment submission and threading works