### PR TITLE
fix(blog): right-align giscus reaction buttons

### DIFF
--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -131,6 +131,12 @@ main {
   display: none;
 }
 
+.gsc-reactions > div {
+  flex: none;
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
 .gsc-reactions button {
   padding: 0.125rem 0.375rem;
 }


### PR DESCRIPTION
## Summary

- Override Tailwind `flex-auto` and `justify-center` utilities on the inner div inside `.gsc-reactions` so the smiley button actually aligns to the right instead of staying centered

## Test plan

- [ ] Deploy and verify reaction button row is right-aligned, not centered
- [ ] Confirm reaction picker popup still works