### PR TITLE
fix(blog): boost specificity on giscus reactions override

### DIFF
--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -131,7 +131,7 @@ main {
   display: none;
 }
 
-.gsc-reactions > div {
+#__next .gsc-reactions > div {
   flex: none;
   justify-content: flex-end;
   margin-top: 0;


### PR DESCRIPTION
## Summary

- Prefix `.gsc-reactions > div` selector with `#__next` to match giscus's Tailwind utility specificity pattern (`#__next .flex-auto` etc. has specificity 1,1,0 which beats our 0,1,1)

## Test plan

- [ ] Deploy and verify reaction smiley button is right-aligned, not centered
- [ ] Confirm reaction picker popup still works