### PR TITLE
fix(blog): inline giscus reactions with comments header

### DIFF
--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -119,41 +119,58 @@ main {
   --color-prettylights-syntax-constant-other-reference-link: #8be9fd;
 }
 
-/* Compact reactions: absolute-position the smiley at the top-right of
-   the widget so it sits on the same row as the "N comments" header. */
+/* Inline reactions with the "N comments" header row.
+   Uses display:contents to flatten .gsc-reactions, .gsc-comments, and
+   .gsc-header so their children become direct flex items of .gsc-main.
+   Order: [1 comment] [smiley + pills] ... [Oldest/Newest] */
 .gsc-main {
-  position: relative;
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 0 !important;
 }
 
-.gsc-reactions {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 1;
-  padding: 0;
+.gsc-reactions,
+.gsc-comments,
+.gsc-header {
+  display: contents !important;
 }
 
 .gsc-reactions-count {
-  display: none;
+  display: none !important;
+}
+
+#__next .gsc-left-header {
+  order: 1;
+  flex: none;
 }
 
 #__next .gsc-reactions > div {
+  order: 2;
   flex: none;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin-top: 0;
+  margin-left: 0.5rem;
+  gap: 0.25rem;
+}
+
+.gsc-right-header {
+  order: 3;
+  margin-left: auto;
+}
+
+.gsc-comment-box {
+  order: 4;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.gsc-timeline {
+  order: 5;
+  width: 100%;
 }
 
 .gsc-reactions button {
   padding: 0.125rem 0.375rem;
-}
-
-/* Push Oldest/Newest buttons left so the smiley doesn't overlap */
-.gsc-right-header {
-  margin-right: 2.5rem;
-}
-
-/* Open the reaction picker leftward so it doesn't clip the right edge */
-.gsc-reactions-popover.left {
-  left: auto !important;
-  right: 0 !important;
 }


### PR DESCRIPTION
## Summary

- Use `display: contents` to flatten `.gsc-reactions`, `.gsc-comments`, and `.gsc-header`, then flex-order their children into a single header row
- Layout: `[1 comment] [smiley + reaction pills] ... [Oldest | Newest]`
- Replaces the absolute positioning approach which broke when reaction pills appeared

## Test plan

- [ ] Deploy and verify reactions sit inline with "1 comment" text
- [ ] Add a reaction and confirm the pill appears on the same row without overlapping
- [ ] Open reaction picker and confirm popover stays within bounds
- [ ] Verify comment box and timeline render correctly below the header