### PR TITLE
fix(blog): move giscus reactions to own row above comment count

### DIFF
--- a/static/css/giscus-theme.css
+++ b/static/css/giscus-theme.css
@@ -119,10 +119,10 @@ main {
   --color-prettylights-syntax-constant-other-reference-link: #8be9fd;
 }
 
-/* Inline reactions with the "N comments" header row.
+/* Reactions on their own row above the comment count.
    Uses display:contents to flatten .gsc-reactions, .gsc-comments, and
    .gsc-header so their children become direct flex items of .gsc-main.
-   Order: [1 comment] [smiley + pills] ... [Oldest/Newest] */
+   Order: [smiley + pills] (full row) / [1 comment ... Oldest/Newest] */
 .gsc-main {
   display: flex !important;
   flex-direction: row !important;
@@ -141,18 +141,19 @@ main {
   display: none !important;
 }
 
-#__next .gsc-left-header {
+#__next .gsc-reactions > div {
   order: 1;
   flex: none;
-}
-
-#__next .gsc-reactions > div {
-  order: 2;
-  flex: none;
+  width: 100%;
   justify-content: flex-start;
   margin-top: 0;
-  margin-left: 0.5rem;
+  padding: 0;
   gap: 0.25rem;
+}
+
+#__next .gsc-left-header {
+  order: 2;
+  flex: none;
 }
 
 .gsc-right-header {


### PR DESCRIPTION
## Summary

- Move reaction pills to their own full-width row above the "N comments" header, left-aligned with no padding
- Prevents reactions from overrunning into the Oldest/Newest buttons on narrow/mobile viewports

## Test plan

- [x] Tested layout with injected CSS in Playwright on desktop (780px) and mobile (375px) viewports
- [x] Verified reaction pills wrap naturally on narrow screens without overlapping other elements
- [x] Purge Cloudflare cache for `/static/css/giscus-theme.css` after deploy
- [x] Verify layout on production blog post with reactions