### PR TITLE
fix(resume): add acute accents to user-visible résumé text

### DIFF
--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -16,8 +16,8 @@ func (d *Deps) Resume() http.HandlerFunc {
 		store := d.Store.Load()
 
 		data := resumeData{PageData: d.basePage("resume")}
-		data.PageTitle = "Resume"
-		data.Description = "Resume of William Findlay"
+		data.PageTitle = "Résumé"
+		data.Description = "Résumé of William Findlay"
 		data.CanonicalURL = d.SiteURL + "/resume"
 
 		if store != nil {

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,7 +60,7 @@
             <ul class="nav__links">
                 <li><a href="/blog"{{if eq .ActiveNav "blog"}} class="active"{{end}}>Blog</a></li>
                 <li><a href="/projects"{{if eq .ActiveNav "projects"}} class="active"{{end}}>Projects</a></li>
-                <li><a href="/resume"{{if eq .ActiveNav "resume"}} class="active"{{end}}>Resume</a></li>
+                <li><a href="/resume"{{if eq .ActiveNav "resume"}} class="active"{{end}}>Résumé</a></li>
             </ul>
         </nav>
     </header>

--- a/templates/resume.html
+++ b/templates/resume.html
@@ -156,6 +156,6 @@
     {{end}}
 </div>
 {{else}}
-<p class="empty-state">Resume not available.</p>
+<p class="empty-state">Résumé not available.</p>
 {{end}}
 {{end}}


### PR DESCRIPTION
## Summary

- Add acute accents (é) to all user-visible instances of "résumé" in nav link, page title, meta description, and empty state message
- URLs, CSS classes, Go identifiers, and template filenames remain unchanged

## Test plan

- [x] `go test ./...` passing
- [x] `gofmt -l .` clean
- [x] `golangci-lint run` clean (0 issues)
- [ ] Verify nav link displays "Résumé" in browser
- [ ] Verify page title and meta description use accented form