### PR TITLE
feat(server): log build metadata via ldflags on startup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,3 +54,6 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
+          build-args: |
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ github.event.head_commit.timestamp }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.25-alpine AS build
 
+ARG COMMIT=unknown
+ARG BUILD_TIME=unknown
+
 RUN apk add --no-cache ca-certificates
 RUN mkdir -p /data/content && chown 65534:65534 /data/content
 
@@ -7,7 +10,9 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /server ./cmd/server
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X github.com/willfindlay/williamfindlaycom/internal/version.Commit=$COMMIT -X github.com/willfindlay/williamfindlaycom/internal/version.BuildTime=$BUILD_TIME" \
+    -o /server ./cmd/server
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,10 +7,17 @@ import (
 	williamfindlaycom "github.com/willfindlay/williamfindlaycom"
 	"github.com/willfindlay/williamfindlaycom/internal/config"
 	"github.com/willfindlay/williamfindlaycom/internal/server"
+	"github.com/willfindlay/williamfindlaycom/internal/version"
 )
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+
+	slog.Info("starting",
+		"version", version.Version,
+		"commit", version.Commit,
+		"build_time", version.BuildTime,
+	)
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildTime = "unknown"
+)


### PR DESCRIPTION
Adds a structured startup log line with version, commit SHA, and build timestamp. The commit and build time are injected at build time via `-ldflags -X` into package-level variables in `internal/version/version.go`. The version field defaults to `"dev"` and isn't set by the build system (it's a placeholder for future tag-based injection). Commit and build time default to `"unknown"` for local `go run` builds.

The Dockerfile accepts `COMMIT` and `BUILD_TIME` as build args and passes them through to `go build`. The Docker CI workflow supplies `github.sha` and `github.event.head_commit.timestamp` so production images carry real commit and timestamp metadata.