### PR TITLE
feat(blog): add reading time estimate and prev/next post navigation

### DIFF
--- a/internal/content/loader.go
+++ b/internal/content/loader.go
@@ -99,6 +99,7 @@ func loadBlogPosts(dir string, store *ContentStore) error {
 		post.Slug = slug
 		post.Content = rendered
 		post.PlainText = extractBody(data)
+		post.ReadingTime = readingTime(post.PlainText)
 		return post, nil
 	})
 	if err != nil {
@@ -237,6 +238,14 @@ func renderInlineMarkdown(s string) template.HTML {
 	out = strings.ReplaceAll(out, "<p>", "")
 	out = strings.ReplaceAll(out, "</p>", "")
 	return template.HTML(strings.TrimSpace(out))
+}
+
+func readingTime(text string) int {
+	words := len(strings.Fields(text))
+	if m := words / 238; m > 0 {
+		return m
+	}
+	return 1
 }
 
 // extractBody strips YAML frontmatter delimiters and returns the markdown body.

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -16,6 +16,7 @@ type BlogPost struct {
 	Tags        []string      `yaml:"tags"`
 	Content     template.HTML // rendered markdown
 	PlainText   string        // raw markdown body (frontmatter stripped), for search
+	ReadingTime int           // estimated minutes to read
 }
 
 type Project struct {

--- a/internal/handler/blog.go
+++ b/internal/handler/blog.go
@@ -23,8 +23,10 @@ type blogListData struct {
 
 type blogPostData struct {
 	PageData
-	Post   *content.BlogPost
-	Giscus config.GiscusConfig
+	Post     *content.BlogPost
+	PrevPost *content.BlogPost // older
+	NextPost *content.BlogPost // newer
+	Giscus   config.GiscusConfig
 }
 
 func (d *Deps) BlogList() http.HandlerFunc {
@@ -114,6 +116,17 @@ func (d *Deps) BlogPost() http.HandlerFunc {
 		}
 
 		data := blogPostData{PageData: d.basePage("blog"), Post: post, Giscus: d.Giscus}
+		for i, p := range store.Posts {
+			if p.Slug == slug {
+				if i+1 < len(store.Posts) {
+					data.PrevPost = &store.Posts[i+1] // older
+				}
+				if i > 0 {
+					data.NextPost = &store.Posts[i-1] // newer
+				}
+				break
+			}
+		}
 		data.PageTitle = post.Title
 		data.Description = post.Description
 		data.CanonicalURL = d.SiteURL + "/blog/" + slug

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -228,16 +228,57 @@ a.tag:hover,
 /* Comments */
 .comments {
   margin-top: var(--space-2xl);
-  padding-top: var(--space-lg);
-  border-top: 1px solid var(--color-border);
 }
 
-.comments__heading {
+/* Reading Time */
+.post__reading-time {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  color: var(--color-text-faint);
+}
+
+/* Post Navigation (prev/next) */
+.post-nav {
+  margin-top: var(--space-2xl);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-lg);
+}
+
+.post-nav__link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.post-nav__link:hover {
+  border-color: var(--color-accent);
+  background: var(--color-bg-raised);
+}
+
+.post-nav__link--prev {
+  grid-column: 1;
+}
+
+.post-nav__link--next {
+  grid-column: 2;
+  text-align: right;
+}
+
+.post-nav__label {
   font-family: "DejaVu Sans", sans-serif;
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-faint);
-  margin-bottom: var(--space-lg);
+}
+
+.post-nav__title {
+  font-size: 0.95rem;
+  color: var(--color-accent);
 }

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -2,6 +2,7 @@
 <article class="post">
     <header class="post__header">
         <time class="post__date" datetime="{{formatDateShort .Post.Date}}">{{formatDate .Post.Date}}</time>
+        <span class="post__reading-time">{{.Post.ReadingTime}} min read</span>
         <h1 class="post__title">{{.Post.Title}}</h1>
         {{if .Post.Tags}}
         <div class="post__tags">
@@ -32,9 +33,24 @@
             </a>
         </div>
     </footer>
+    {{if or .PrevPost .NextPost}}
+    <nav class="post-nav" aria-label="Post navigation">
+        {{if .PrevPost}}
+        <a href="/blog/{{.PrevPost.Slug}}" class="post-nav__link post-nav__link--prev">
+            <span class="post-nav__label">Older</span>
+            <span class="post-nav__title">{{.PrevPost.Title}}</span>
+        </a>
+        {{end}}
+        {{if .NextPost}}
+        <a href="/blog/{{.NextPost.Slug}}" class="post-nav__link post-nav__link--next">
+            <span class="post-nav__label">Newer</span>
+            <span class="post-nav__title">{{.NextPost.Title}}</span>
+        </a>
+        {{end}}
+    </nav>
+    {{end}}
     {{if .Giscus.Repo}}
     <section class="comments">
-        <h2 class="comments__heading">Comments</h2>
         <div class="giscus-container"
              data-repo="{{.Giscus.Repo}}"
              data-repo-id="{{.Giscus.RepoID}}"


### PR DESCRIPTION
Adds two features to blog post pages: an estimated reading time in the post header and prev/next navigation links between posts.

Reading time is computed from the word count of the markdown body (frontmatter stripped) divided by 238 WPM, with a minimum of 1 minute. The calculation runs during content loading and is stored on the `BlogPost` struct as `ReadingTime`.

The post handler finds the current post's index in `store.Posts` (sorted newest-first) and sets `PrevPost` (older, index+1) and `NextPost` (newer, index-1) on the template data. The nav section renders as a two-column grid between the share footer and the comments section, with "Older" and "Newer" labels.

Verified with Playwright against three blog posts: the middle post shows both Older and Newer links, the newest post shows only Older, and the oldest shows only Newer. Reading time displays correctly (e.g. "4 min read" for a shorter post, "8 min read" for a longer one).