### PR TITLE
feat(blog): show related posts based on tag overlap

### DIFF
--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -3,6 +3,7 @@ package content
 import (
 	"fmt"
 	"html/template"
+	"sort"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -160,4 +161,59 @@ type ContentStore struct {
 	ProjectsBySlug map[string]*Project
 
 	Resume *Resume
+}
+
+// RelatedPosts returns up to `limit` posts related to the given slug,
+// scored by number of overlapping tags with ties broken by recency.
+func (cs *ContentStore) RelatedPosts(slug string, limit int) []*BlogPost {
+	post, ok := cs.PostsBySlug[slug]
+	if !ok || len(post.Tags) == 0 {
+		return nil
+	}
+
+	tagSet := make(map[string]bool, len(post.Tags))
+	for _, t := range post.Tags {
+		tagSet[t] = true
+	}
+
+	type scored struct {
+		post  *BlogPost
+		score int
+	}
+
+	seen := map[string]bool{slug: true}
+	var candidates []scored
+
+	for _, t := range post.Tags {
+		for _, p := range cs.PostsByTag[t] {
+			if seen[p.Slug] {
+				continue
+			}
+			seen[p.Slug] = true
+			score := 0
+			for _, pt := range p.Tags {
+				if tagSet[pt] {
+					score++
+				}
+			}
+			candidates = append(candidates, scored{post: p, score: score})
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].post.Date.After(candidates[j].post.Date)
+	})
+
+	n := limit
+	if n > len(candidates) {
+		n = len(candidates)
+	}
+	result := make([]*BlogPost, n)
+	for i := 0; i < n; i++ {
+		result[i] = candidates[i].post
+	}
+	return result
 }

--- a/internal/handler/blog.go
+++ b/internal/handler/blog.go
@@ -23,10 +23,11 @@ type blogListData struct {
 
 type blogPostData struct {
 	PageData
-	Post     *content.BlogPost
-	PrevPost *content.BlogPost // older
-	NextPost *content.BlogPost // newer
-	Giscus   config.GiscusConfig
+	Post         *content.BlogPost
+	PrevPost     *content.BlogPost // older
+	NextPost     *content.BlogPost // newer
+	RelatedPosts []*content.BlogPost
+	Giscus       config.GiscusConfig
 }
 
 func (d *Deps) BlogList() http.HandlerFunc {
@@ -132,6 +133,7 @@ func (d *Deps) BlogPost() http.HandlerFunc {
 		data.CanonicalURL = d.SiteURL + "/blog/" + slug
 		data.OGType = "article"
 		data.JSONLD = buildBlogPostingJSONLD(post, d.SiteURL)
+		data.RelatedPosts = store.RelatedPosts(slug, 3)
 
 		d.render(w, "templates/blog/post.html", data)
 	}

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -225,6 +225,67 @@ a.tag:hover,
   border-color: var(--color-accent);
 }
 
+/* Related Posts */
+.related-posts {
+  margin-top: var(--space-2xl);
+}
+
+.related-posts__heading {
+  font-family: "DejaVu Sans", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-faint);
+  margin-bottom: var(--space-lg);
+}
+
+.related-posts__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: var(--space-md);
+}
+
+.related-posts__card {
+  display: block;
+  padding: var(--space-lg);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.related-posts__card:hover {
+  border-color: var(--color-accent);
+  transform: translateY(-2px);
+}
+
+.related-posts__date {
+  display: block;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  margin-bottom: var(--space-xs);
+}
+
+.related-posts__title {
+  font-family: "DejaVu Sans", sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  margin-bottom: var(--space-xs);
+  transition: color var(--transition-fast);
+}
+
+.related-posts__card:hover .related-posts__title {
+  color: var(--color-accent);
+}
+
+.related-posts__description {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
 /* Comments */
 .comments {
   margin-top: var(--space-2xl);
@@ -243,6 +304,16 @@ a.tag:hover,
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--space-lg);
+}
+
+.post-nav__heading {
+  grid-column: 1 / -1;
+  font-family: "DejaVu Sans", sans-serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-faint);
 }
 
 .post-nav__link {
@@ -264,7 +335,7 @@ a.tag:hover,
   grid-column: 1;
 }
 
-.post-nav__link--next {
+.post-nav__link--prev ~ .post-nav__link--next {
   grid-column: 2;
   text-align: right;
 }

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -35,6 +35,7 @@
     </footer>
     {{if or .PrevPost .NextPost}}
     <nav class="post-nav" aria-label="Post navigation">
+        <h2 class="post-nav__heading">Up Next</h2>
         {{if .PrevPost}}
         <a href="/blog/{{.PrevPost.Slug}}" class="post-nav__link post-nav__link--prev">
             <span class="post-nav__label">Older</span>
@@ -48,6 +49,20 @@
         </a>
         {{end}}
     </nav>
+    {{end}}
+    {{if .RelatedPosts}}
+    <section class="related-posts">
+        <h2 class="related-posts__heading">Related Posts</h2>
+        <div class="related-posts__grid">
+            {{range .RelatedPosts}}
+            <a href="/blog/{{.Slug}}" class="related-posts__card">
+                <time class="related-posts__date" datetime="{{formatDateShort .Date}}">{{formatDate .Date}}</time>
+                <h3 class="related-posts__title">{{.Title}}</h3>
+                <p class="related-posts__description">{{.Description}}</p>
+            </a>
+            {{end}}
+        </div>
+    </section>
     {{end}}
     {{if .Giscus.Repo}}
     <section class="comments">


### PR DESCRIPTION
Adds a "Related Posts" section to blog post pages, displayed between the share footer and comments. Related posts are scored by the number of shared tags with the current post, with ties broken by recency. The handler requests up to 3 related posts per page.

The `RelatedPosts` method on `ContentStore` builds a candidate set by iterating the current post's tags through `PostsByTag`, deduplicating and scoring each candidate, then sorting by score descending and date descending. Posts with no tags or no tag overlap produce an empty result, and the section is hidden entirely via a template conditional.

Each related post card shows the date, title, and description in an auto-fill responsive grid. The section was verified with Playwright, which correctly showed no related posts for the current content (the three existing blog posts have no overlapping tags). The code, template, and CSS are all in place for when posts share tags.