### PR TITLE
feat(server): bundle CSS with content-hash for immutable caching

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -49,8 +49,14 @@ func xmlEscape(s string) string {
 	return r.Replace(s)
 }
 
-func New(fsys fs.FS) (*Renderer, error) {
-	base, err := template.New("base").Funcs(funcMap).ParseFS(fsys, "templates/base.html")
+func New(fsys fs.FS, cssBundlePath string) (*Renderer, error) {
+	fmap := template.FuncMap{}
+	for k, v := range funcMap {
+		fmap[k] = v
+	}
+	fmap["cssBundle"] = func() string { return cssBundlePath }
+
+	base, err := template.New("base").Funcs(fmap).ParseFS(fsys, "templates/base.html")
 	if err != nil {
 		return nil, fmt.Errorf("parsing base template: %w", err)
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -22,6 +22,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /sitemap.xml", s.deps.Sitemap())
 	mux.HandleFunc("GET /robots.txt", s.deps.Robots())
 
+	mux.HandleFunc("GET "+s.cssBundlePath, s.serveCSSBundle)
+
 	staticFS, err := fs.Sub(s.static, "static")
 	if err != nil {
 		panic(fmt.Sprintf("embedded static fs: %v", err))
@@ -35,4 +37,10 @@ func (s *Server) routes() http.Handler {
 	h = securityHeaders(h)
 	h = logging(h)
 	return h
+}
+
+func (s *Server) serveCSSBundle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/css; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.Write(s.cssBundle) //nolint:errcheck
 }

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -20,7 +20,12 @@ import (
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	renderer, err := render.New(williamfindlaycom.Embedded)
+	bundleBytes, bundlePath, err := buildCSSBundle(williamfindlaycom.Embedded)
+	if err != nil {
+		t.Fatalf("buildCSSBundle: %v", err)
+	}
+
+	renderer, err := render.New(williamfindlaycom.Embedded, bundlePath)
 	if err != nil {
 		t.Fatalf("render.New: %v", err)
 	}
@@ -73,10 +78,12 @@ More content.
 	}
 
 	srv := &Server{
-		cfg:    &config.Config{},
-		static: williamfindlaycom.Embedded,
-		store:  store,
-		deps:   deps,
+		cfg:           &config.Config{},
+		static:        williamfindlaycom.Embedded,
+		store:         store,
+		deps:          deps,
+		cssBundle:     bundleBytes,
+		cssBundlePath: bundlePath,
 	}
 
 	return httptest.NewServer(srv.routes())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -17,14 +20,21 @@ import (
 )
 
 type Server struct {
-	cfg    *config.Config
-	static fs.FS
-	store  *content.AtomicStore
-	deps   *handler.Deps
+	cfg           *config.Config
+	static        fs.FS
+	store         *content.AtomicStore
+	deps          *handler.Deps
+	cssBundle     []byte
+	cssBundlePath string
 }
 
 func New(cfg *config.Config, embedded fs.FS) (*Server, error) {
-	renderer, err := render.New(embedded)
+	bundleBytes, bundlePath, err := buildCSSBundle(embedded)
+	if err != nil {
+		return nil, fmt.Errorf("building CSS bundle: %w", err)
+	}
+
+	renderer, err := render.New(embedded, bundlePath)
 	if err != nil {
 		return nil, fmt.Errorf("initializing renderer: %w", err)
 	}
@@ -40,11 +50,39 @@ func New(cfg *config.Config, embedded fs.FS) (*Server, error) {
 	}
 
 	return &Server{
-		cfg:    cfg,
-		static: embedded,
-		store:  store,
-		deps:   deps,
+		cfg:           cfg,
+		static:        embedded,
+		store:         store,
+		deps:          deps,
+		cssBundle:     bundleBytes,
+		cssBundlePath: bundlePath,
 	}, nil
+}
+
+func buildCSSBundle(fsys fs.FS) ([]byte, string, error) {
+	cssFiles := []string{
+		"static/css/reset.css",
+		"static/css/typography.css",
+		"static/css/layout.css",
+		"static/css/components.css",
+		"static/css/syntax.css",
+		"static/css/main.css",
+	}
+
+	var buf bytes.Buffer
+	for _, f := range cssFiles {
+		data, err := fs.ReadFile(fsys, f)
+		if err != nil {
+			return nil, "", fmt.Errorf("reading %s: %w", f, err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+
+	h := sha256.Sum256(buf.Bytes())
+	hash := hex.EncodeToString(h[:8]) // 16 hex chars is plenty
+	path := fmt.Sprintf("/static/css/bundle.%s.css", hash)
+	return buf.Bytes(), path, nil
 }
 
 func (s *Server) Run() error {

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,12 +31,7 @@
     <link rel="preload" href="/static/fonts/DejaVuSans-Bold.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="/static/fonts/SourceSerif4-Variable.woff2" as="font" type="font/woff2" crossorigin>
 
-    <link rel="stylesheet" href="/static/css/reset.css">
-    <link rel="stylesheet" href="/static/css/typography.css">
-    <link rel="stylesheet" href="/static/css/layout.css">
-    <link rel="stylesheet" href="/static/css/components.css">
-    <link rel="stylesheet" href="/static/css/syntax.css">
-    <link rel="stylesheet" href="/static/css/main.css">
+    <link rel="stylesheet" href="{{cssBundle}}">
 </head>
 <body>
     <canvas id="particles" aria-hidden="true"


### PR DESCRIPTION
Replaces the six individual CSS `<link>` tags in `base.html` with a single bundled stylesheet served at a content-hashed path (e.g. `/static/css/bundle.aca03f4882b5df9b.css`). The hash is the first 8 bytes of a SHA-256 over the concatenated CSS, encoded as 16 hex characters. Since the path changes whenever the CSS content changes, the bundle is served with `Cache-Control: public, max-age=31536000, immutable`.

The bundle is built at startup by `buildCSSBundle`, which reads the six CSS files from the embedded FS in the same order they were previously linked, concatenates them, and computes the hash. The resulting bytes and path are stored on the `Server` struct and injected into templates via a `cssBundle` template function registered through `render.New`. A dedicated route handler serves the bundle bytes directly, bypassing the static file server.

The giscus custom theme CSS (`giscus-theme.css`) is deliberately not included in the bundle because it's loaded cross-origin by the giscus iframe and needs its own CORS header. The existing `cacheStatic` middleware and CORS logic for that file remain unchanged.

Existing tests are updated to call `buildCSSBundle` and pass the bundle path to `render.New`. Verified with Playwright that the HTML contains a single CSS link with the hashed path, the bundle responds with `immutable` cache headers, and the giscus CORS header still works on the individual CSS file.