### PR TITLE
feat(ui): add IntersectionObserver scroll reveal for cards and content

### DIFF
--- a/static/css/components.css
+++ b/static/css/components.css
@@ -353,3 +353,25 @@ a.tag:hover,
   font-size: 0.95rem;
   color: var(--color-accent);
 }
+
+/* Scroll Reveal */
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(40px);
+  transition:
+    opacity 600ms ease-out,
+    transform 600ms ease-out;
+}
+
+[data-reveal].revealed {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}

--- a/static/js/reveal.js
+++ b/static/js/reveal.js
@@ -1,0 +1,43 @@
+(function () {
+  "use strict";
+
+  var reducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+
+  function reveal(entries) {
+    entries.forEach(function (entry) {
+      if (entry.isIntersecting) {
+        entry.target.classList.add("revealed");
+        observer.unobserve(entry.target);
+      }
+    });
+  }
+
+  var observer = new IntersectionObserver(reveal, {
+    threshold: 0.1,
+    rootMargin: "0px 0px -40px 0px",
+  });
+
+  function observe() {
+    var elements = document.querySelectorAll("[data-reveal]");
+    elements.forEach(function (el, i) {
+      if (reducedMotion) {
+        el.classList.add("revealed");
+        return;
+      }
+      // Stagger delay: 50ms per item, capped at 300ms
+      var delay = Math.min(i * 50, 300);
+      el.style.transitionDelay = delay + "ms";
+      observer.observe(el);
+    });
+  }
+
+  // Initial observation
+  observe();
+
+  // Re-observe after SPA navigation
+  document.addEventListener("spa:navigate", function () {
+    observe();
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,5 +79,6 @@
     <script src="/static/js/particles.js"></script>
     <script src="/static/js/navigation.js"></script>
     <script src="/static/js/comments.js" defer></script>
+    <script src="/static/js/reveal.js" defer></script>
 </body>
 </html>{{end}}

--- a/templates/blog/list.html
+++ b/templates/blog/list.html
@@ -16,7 +16,7 @@
 
 <div class="post-grid">
     {{range $i, $post := .Posts}}
-    <article class="card{{if and (eq $i 0) (not $.ActiveTags) (not $.SearchQuery)}} card--featured{{end}}" data-slug="{{$post.Slug}}">
+    <article class="card{{if and (eq $i 0) (not $.ActiveTags) (not $.SearchQuery)}} card--featured{{end}}" data-slug="{{$post.Slug}}" data-reveal>
         <a href="/blog/{{$post.Slug}}" class="card__link">
             <time class="card__date" datetime="{{formatDateShort $post.Date}}">{{formatDate $post.Date}}</time>
             <h3 class="card__title">{{$post.Title}}</h3>

--- a/templates/blog/post.html
+++ b/templates/blog/post.html
@@ -1,5 +1,5 @@
 {{define "content"}}
-<article class="post">
+<article class="post" data-reveal>
     <header class="post__header">
         <time class="post__date" datetime="{{formatDateShort .Post.Date}}">{{formatDate .Post.Date}}</time>
         <span class="post__reading-time">{{.Post.ReadingTime}} min read</span>

--- a/templates/home.html
+++ b/templates/home.html
@@ -9,7 +9,7 @@
     <h2 class="section__title">Recent Posts</h2>
     <div class="post-grid">
         {{range $i, $post := .RecentPosts}}
-        <article class="card{{if eq $i 0}} card--featured{{end}}">
+        <article class="card{{if eq $i 0}} card--featured{{end}}" data-reveal>
             <a href="/blog/{{$post.Slug}}" class="card__link">
                 <time class="card__date" datetime="{{formatDateShort $post.Date}}">{{formatDate $post.Date}}</time>
                 <h3 class="card__title">{{$post.Title}}</h3>
@@ -31,7 +31,7 @@
     <h2 class="section__title">Featured Projects</h2>
     <div class="project-grid">
         {{range .FeaturedProjects}}
-        <article class="card">
+        <article class="card" data-reveal>
             <a href="/projects/{{.Slug}}" class="card__link">
                 <h3 class="card__title">{{.Title}}</h3>
                 <p class="card__description">{{.Description}}</p>

--- a/templates/projects/list.html
+++ b/templates/projects/list.html
@@ -5,7 +5,7 @@
 
 <div class="project-grid">
     {{range .Projects}}
-    <article class="card">
+    <article class="card" data-reveal>
         <a href="/projects/{{.Slug}}" class="card__link">
             <h3 class="card__title">{{.Title}}</h3>
             <p class="card__description">{{.Description}}</p>


### PR DESCRIPTION
Adds a fade-and-slide-up entrance animation to card elements and blog post articles using IntersectionObserver. Elements marked with `data-reveal` start at opacity 0 with a 20px vertical offset, then transition to their final position when they enter the viewport (10% threshold, -40px bottom margin). Each element is unobserved after revealing so the animation fires only once.

Stagger delays are applied per element (50ms increments, capped at 300ms) to create a cascading effect when multiple cards are visible simultaneously. The `prefers-reduced-motion` media query disables the animation entirely, both in CSS (immediate opacity/transform) and in JS (the `revealed` class is added synchronously without observing). The script also re-observes on a `spa:navigate` custom event for future SPA-style page transitions.

The `data-reveal` attribute is added to card articles on the homepage (recent posts, featured projects), the blog list, the projects list, and the blog post article element. The script is loaded with `defer` in `base.html`.

Verified with Playwright: elements start without the `revealed` class, then gain it progressively as the page is scrolled.