### PR TITLE
fix(seo): fix JSON-LD escaping and add /index redirect

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -29,7 +29,7 @@ type PageData struct {
 	OGType       string
 	OGImage      string
 	Author       string
-	JSONLD       template.HTML
+	JSONLD       template.JS
 	ActiveNav    string
 	Particles    config.ParticleConfig
 }

--- a/internal/handler/jsonld.go
+++ b/internal/handler/jsonld.go
@@ -42,16 +42,16 @@ type jsonLDCollectionPage struct {
 	URL         string `json:"url"`
 }
 
-func marshalJSONLD(v any) template.HTML {
+func marshalJSONLD(v any) template.JS {
 	b, err := json.Marshal(v)
 	if err != nil {
 		slog.Error("jsonld marshal error", "err", err)
 		return ""
 	}
-	return template.HTML(b)
+	return template.JS(b)
 }
 
-func buildHomeJSONLD(siteTitle, siteURL string) template.HTML {
+func buildHomeJSONLD(siteTitle, siteURL string) template.JS {
 	graph := []any{
 		jsonLDWebSite{
 			jsonLDBase: jsonLDBase{Context: "https://schema.org", Type: "WebSite"},
@@ -73,10 +73,10 @@ func buildHomeJSONLD(siteTitle, siteURL string) template.HTML {
 		slog.Error("jsonld marshal error", "err", err)
 		return ""
 	}
-	return template.HTML(b)
+	return template.JS(b)
 }
 
-func buildBlogPostingJSONLD(post *content.BlogPost, siteURL string) template.HTML {
+func buildBlogPostingJSONLD(post *content.BlogPost, siteURL string) template.JS {
 	ld := jsonLDBlogPosting{
 		jsonLDBase:    jsonLDBase{Context: "https://schema.org", Type: "BlogPosting"},
 		Headline:      post.Title,
@@ -92,7 +92,7 @@ func buildBlogPostingJSONLD(post *content.BlogPost, siteURL string) template.HTM
 	return marshalJSONLD(ld)
 }
 
-func buildCollectionPageJSONLD(name, description, url string) template.HTML {
+func buildCollectionPageJSONLD(name, description, url string) template.JS {
 	ld := jsonLDCollectionPage{
 		jsonLDBase:  jsonLDBase{Context: "https://schema.org", Type: "CollectionPage"},
 		Name:        name,

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -21,6 +21,9 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /feed.xml", s.deps.Feed())
 	mux.HandleFunc("GET /sitemap.xml", s.deps.Sitemap())
 	mux.HandleFunc("GET /robots.txt", s.deps.Robots())
+	mux.HandleFunc("GET /index", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	})
 
 	mux.HandleFunc("GET "+s.cssBundlePath, s.serveCSSBundle)
 


### PR DESCRIPTION
Google Search Console flagged two issues: JSON-LD structured data rendering as a JavaScript string literal instead of a JSON object, and /index returning 404.

The JSON-LD problem was caused by using `template.HTML` for the JSONLD field in PageData. Since the template renders it inside a `<script type="application/ld+json">` tag, `html/template` treats the context as JavaScript and wraps `template.HTML` values in quotes with backslash escaping. Changing the type to `template.JS` tells the engine to emit the value as-is, producing valid JSON.

The /index 404 happened because the catch-all `GET /` route in routes.go dispatches to `Home()`, which returns 404 for any path other than `/` exactly. A new route 301-redirects `/index` to `/`, consolidating crawl signals on the canonical URL.

Tests pass, vet and lint are clean.