### PR TITLE
feat(seo): add JSON Feed 1.1 endpoint at /feed.json

### DIFF
--- a/internal/handler/jsonfeed.go
+++ b/internal/handler/jsonfeed.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type jsonFeed struct {
+	Version     string         `json:"version"`
+	Title       string         `json:"title"`
+	HomePageURL string         `json:"home_page_url"`
+	FeedURL     string         `json:"feed_url"`
+	Items       []jsonFeedItem `json:"items"`
+}
+
+type jsonFeedItem struct {
+	ID            string   `json:"id"`
+	URL           string   `json:"url"`
+	Title         string   `json:"title"`
+	ContentHTML   string   `json:"content_html"`
+	Summary       string   `json:"summary,omitempty"`
+	DatePublished string   `json:"date_published"`
+	Tags          []string `json:"tags,omitempty"`
+}
+
+func (d *Deps) JSONFeed() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		store := d.Store.Load()
+
+		feed := jsonFeed{
+			Version:     "https://jsonfeed.org/version/1.1",
+			Title:       d.SiteTitle,
+			HomePageURL: d.SiteURL + "/",
+			FeedURL:     d.SiteURL + "/feed.json",
+		}
+
+		if store != nil {
+			feed.Items = make([]jsonFeedItem, len(store.Posts))
+			for i, p := range store.Posts {
+				feed.Items[i] = jsonFeedItem{
+					ID:            d.SiteURL + "/blog/" + p.Slug,
+					URL:           d.SiteURL + "/blog/" + p.Slug,
+					Title:         p.Title,
+					ContentHTML:   string(p.Content),
+					Summary:       p.Description,
+					DatePublished: p.Date.Format(time.RFC3339),
+					Tags:          p.Tags,
+				}
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/feed+json; charset=utf-8")
+		if err := json.NewEncoder(w).Encode(feed); err != nil {
+			slog.Error("json feed encode error", "err", err)
+		}
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -19,6 +19,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /projects/{slug}", s.deps.ProjectDetail())
 	mux.HandleFunc("GET /resume", s.deps.Resume())
 	mux.HandleFunc("GET /feed.xml", s.deps.Feed())
+	mux.HandleFunc("GET /feed.json", s.deps.JSONFeed())
 	mux.HandleFunc("GET /sitemap.xml", s.deps.Sitemap())
 	mux.HandleFunc("GET /robots.txt", s.deps.Robots())
 	mux.HandleFunc("GET /index", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -490,5 +491,62 @@ func TestRoutes_Feed(t *testing.T) {
 	body := readBody(t, resp)
 	if !strings.Contains(body, "<feed") {
 		t.Error("expected Atom feed element in body")
+	}
+}
+
+func TestRoutes_JSONFeed(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/feed.json")
+	if err != nil {
+		t.Fatalf("GET /feed.json: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/feed+json") {
+		t.Errorf("expected application/feed+json content type, got %q", ct)
+	}
+
+	body := readBody(t, resp)
+
+	var feed struct {
+		Version     string `json:"version"`
+		Title       string `json:"title"`
+		HomePageURL string `json:"home_page_url"`
+		FeedURL     string `json:"feed_url"`
+		Items       []struct {
+			ID          string   `json:"id"`
+			URL         string   `json:"url"`
+			Title       string   `json:"title"`
+			ContentHTML string   `json:"content_html"`
+			Tags        []string `json:"tags"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(body), &feed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if feed.Version != "https://jsonfeed.org/version/1.1" {
+		t.Errorf("expected JSON Feed 1.1 version, got %q", feed.Version)
+	}
+	if feed.Title != "Test Site" {
+		t.Errorf("expected title 'Test Site', got %q", feed.Title)
+	}
+	if len(feed.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(feed.Items))
+	}
+
+	// Posts are sorted by date descending, so Second Post (2024-01-02) comes first
+	if feed.Items[0].Title != "Second Post" {
+		t.Errorf("expected first item 'Second Post', got %q", feed.Items[0].Title)
+	}
+	if feed.Items[0].ContentHTML == "" {
+		t.Error("expected non-empty content_html")
 	}
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,7 @@
     {{if .OGImage}}<meta name="twitter:image" content="{{.OGImage}}">{{end}}
 
     <link rel="alternate" type="application/atom+xml" title="{{.SiteTitle}}" href="/feed.xml">
+    <link rel="alternate" type="application/feed+json" title="{{.SiteTitle}}" href="/feed.json">
     <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 
     {{if .JSONLD}}<script type="application/ld+json">{{.JSONLD}}</script>{{end}}


### PR DESCRIPTION
Adds a JSON Feed 1.1 endpoint at `/feed.json` alongside the existing Atom feed at `/feed.xml`. The handler in `internal/handler/jsonfeed.go` marshals a struct directly with `encoding/json` rather than using a template, which is simpler and avoids the XML escaping concerns of the Atom feed. Each item includes `content_html` with the full rendered post HTML, `summary` from the post description, tags, and an ISO 8601 publication date.

A `<link rel="alternate" type="application/feed+json">` discovery tag is added to `templates/base.html` so feed readers can auto-detect the JSON feed. The route is registered in `routes.go` next to the existing `/feed.xml` route.

The test in `routes_test.go` verifies the Content-Type header, valid JSON structure, correct version string, expected item count and ordering, and non-empty `content_html`. All existing tests pass.

Closes #37