### PR TITLE
feat(frontend): add reading progress indicator to blog posts

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -16,6 +16,18 @@
   z-index: 100;
 }
 
+.site-header::after {
+  content: "";
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--color-accent);
+  transform: scaleX(var(--reading-progress, 0));
+  transform-origin: left;
+}
+
 .nav {
   display: flex;
   align-items: center;
@@ -494,7 +506,6 @@
 .resume-oss li::marker {
   color: var(--color-accent);
 }
-
 
 /* Responsive */
 @media (max-width: 768px) {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -63,7 +63,6 @@ body {
   pointer-events: none;
 }
 
-.site-header,
 .main,
 .site-footer {
   position: relative;

--- a/static/js/progress.js
+++ b/static/js/progress.js
@@ -1,0 +1,62 @@
+(function () {
+  "use strict";
+
+  var header = document.querySelector(".site-header");
+  var reducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  ).matches;
+  var ticking = false;
+
+  function getArticle() {
+    return document.querySelector(".post");
+  }
+
+  function update() {
+    ticking = false;
+    var article = getArticle();
+    if (!article || !header) {
+      return;
+    }
+
+    var rect = article.getBoundingClientRect();
+    var articleTop = rect.top + window.scrollY;
+    var scrollable = article.offsetHeight - window.innerHeight;
+
+    if (scrollable <= 0) {
+      header.style.setProperty("--reading-progress", "1");
+      return;
+    }
+
+    var progress = (window.scrollY - articleTop) / scrollable;
+    if (progress < 0) progress = 0;
+    if (progress > 1) progress = 1;
+
+    header.style.setProperty("--reading-progress", progress);
+  }
+
+  function onScroll() {
+    if (!ticking) {
+      requestAnimationFrame(update);
+      ticking = true;
+    }
+  }
+
+  function bind() {
+    if (reducedMotion) return;
+    if (getArticle()) {
+      window.addEventListener("scroll", onScroll, { passive: true });
+      update();
+    } else {
+      window.removeEventListener("scroll", onScroll);
+      if (header) {
+        header.style.removeProperty("--reading-progress");
+      }
+    }
+  }
+
+  bind();
+
+  document.addEventListener("spa:navigate", function () {
+    bind();
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -81,6 +81,7 @@
     <script src="/static/js/navigation.js"></script>
     <script src="/static/js/comments.js" defer></script>
     <script src="/static/js/reveal.js" defer></script>
+    <script src="/static/js/progress.js" defer></script>
     <script src="/static/js/codeblocks.js" defer></script>
 </body>
 </html>{{end}}


### PR DESCRIPTION
A `::after` pseudo-element on `.site-header` overlays the existing bottom border with the accent color, scaling from 0 to 1 as the reader scrolls through a blog post. On non-blog pages the `--reading-progress` custom property is unset, so `scaleX(0)` keeps the overlay invisible and the border looks the same as before.

A new `progress.js` script calculates scroll progress relative to the `.post` element and sets the custom property on the header via `requestAnimationFrame` throttling. It rebinds on `spa:navigate` events and clears the property when navigating away from a blog post.

The `.site-header` was already `position: sticky` in `layout.css`, but `main.css` overrode it with `position: relative` in a combined rule that layers content above the particles canvas. Removed `.site-header` from that rule since the header's own `z-index: 100` already handles stacking.

Tested by running the Docker container locally and verifying with Playwright that the progress bar fills from 0 to 1 when scrolling a blog post, and that the bar disappears after SPA navigation to the blog list. All existing Go tests pass.

Closes #32