### PR TITLE
feat(seo): add lastmod to static sitemap pages

### DIFF
--- a/internal/handler/sitemap.go
+++ b/internal/handler/sitemap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/willfindlay/williamfindlaycom/internal/content"
 )
@@ -12,6 +13,10 @@ type sitemapData struct {
 	SiteURL  string
 	Posts    []content.BlogPost
 	Projects []content.Project
+
+	BlogLastmod     time.Time
+	ProjectsLastmod time.Time
+	GlobalLastmod   time.Time
 }
 
 func (d *Deps) Sitemap() http.HandlerFunc {
@@ -25,6 +30,17 @@ func (d *Deps) Sitemap() http.HandlerFunc {
 		if store != nil {
 			data.Posts = store.Posts
 			data.Projects = store.Projects
+
+			if len(store.Posts) > 0 {
+				data.BlogLastmod = store.Posts[0].Date
+				data.GlobalLastmod = store.Posts[0].Date
+			}
+			if len(store.Projects) > 0 {
+				data.ProjectsLastmod = store.Projects[0].Date
+				if data.ProjectsLastmod.After(data.GlobalLastmod) {
+					data.GlobalLastmod = data.ProjectsLastmod
+				}
+			}
 		}
 
 		var buf bytes.Buffer

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -300,6 +300,31 @@ func TestRoutes_Sitemap(t *testing.T) {
 	if !strings.Contains(body, "/blog/test-post") {
 		t.Error("expected test post URL in sitemap")
 	}
+
+	// Static pages should have lastmod derived from content dates.
+	// The newest post is 2024-01-02, so blog and global lastmod use that date.
+	if !strings.Contains(body, "<loc>http://localhost</loc>") {
+		t.Error("expected home URL in sitemap")
+	}
+	if !strings.Contains(body, "<loc>http://localhost/blog</loc>") {
+		t.Error("expected blog URL in sitemap")
+	}
+	// Home and blog entries should have lastmod from the newest post
+	wantLastmod := "2024-01-02T00:00:00Z"
+	if !strings.Contains(body, "<loc>http://localhost</loc>\n        <lastmod>"+wantLastmod+"</lastmod>") {
+		t.Errorf("expected home lastmod %s in sitemap", wantLastmod)
+	}
+	if !strings.Contains(body, "<loc>http://localhost/blog</loc>\n        <lastmod>"+wantLastmod+"</lastmod>") {
+		t.Errorf("expected blog lastmod %s in sitemap", wantLastmod)
+	}
+	// Resume should also use global lastmod
+	if !strings.Contains(body, "<loc>http://localhost/resume</loc>\n        <lastmod>"+wantLastmod+"</lastmod>") {
+		t.Errorf("expected resume lastmod %s in sitemap", wantLastmod)
+	}
+	// Projects page should have no lastmod (no project content in test fixture)
+	if strings.Contains(body, "<loc>http://localhost/projects</loc>\n        <lastmod>") {
+		t.Error("did not expect projects lastmod with no project content")
+	}
 }
 
 func TestRoutes_BlogPost(t *testing.T) {

--- a/templates/sitemap.xml
+++ b/templates/sitemap.xml
@@ -2,15 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>{{.SiteURL}}</loc>
+        {{if not .GlobalLastmod.IsZero}}<lastmod>{{formatRFC3339 .GlobalLastmod}}</lastmod>{{end}}
     </url>
     <url>
         <loc>{{.SiteURL}}/blog</loc>
+        {{if not .BlogLastmod.IsZero}}<lastmod>{{formatRFC3339 .BlogLastmod}}</lastmod>{{end}}
     </url>
     <url>
         <loc>{{.SiteURL}}/projects</loc>
+        {{if not .ProjectsLastmod.IsZero}}<lastmod>{{formatRFC3339 .ProjectsLastmod}}</lastmod>{{end}}
     </url>
     <url>
         <loc>{{.SiteURL}}/resume</loc>
+        {{if not .GlobalLastmod.IsZero}}<lastmod>{{formatRFC3339 .GlobalLastmod}}</lastmod>{{end}}
     </url>
     {{range .Posts}}
     <url>


### PR DESCRIPTION
The four static sitemap entries (/, /blog, /projects, /resume) had no `<lastmod>` elements, while individual blog post and project URLs already included them from frontmatter dates. This adds lastmod to the static entries by deriving dates from the content store: /blog gets the most recent post date, /projects gets the most recent project date, and / and /resume get the newer of the two. When a content type has no entries, the `<lastmod>` element is omitted rather than emitting a zero date.

All existing tests pass, and `TestRoutes_Sitemap` is extended to verify that the static entries carry the expected lastmod values.

Closes #31.