### PR TITLE
feat(content): load redirect map from _redirects.yaml in content repo

### DIFF
--- a/internal/content/loader.go
+++ b/internal/content/loader.go
@@ -101,6 +101,7 @@ func LoadFromDir(dir string) (*ContentStore, error) {
 		PostsBySlug:    make(map[string]*BlogPost),
 		PostsByTag:     make(map[string][]*BlogPost),
 		ProjectsBySlug: make(map[string]*Project),
+		Redirects:      make(map[string]Redirect),
 	}
 
 	if err := loadBlogPosts(filepath.Join(dir, "blog"), store); err != nil {
@@ -113,6 +114,10 @@ func LoadFromDir(dir string) (*ContentStore, error) {
 
 	if err := loadResume(filepath.Join(dir, "resume"), store); err != nil {
 		return nil, fmt.Errorf("loading resume: %w", err)
+	}
+
+	if err := loadRedirects(dir, store); err != nil {
+		return nil, fmt.Errorf("loading redirects: %w", err)
 	}
 
 	return store, nil
@@ -267,6 +272,43 @@ func loadResume(dir string, store *ContentStore) error {
 	}
 
 	store.Resume = &resume
+	return nil
+}
+
+func loadRedirects(dir string, store *ContentStore) error {
+	path := filepath.Join(dir, "_redirects.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var redirects []Redirect
+	if err := yaml.Unmarshal(data, &redirects); err != nil {
+		return fmt.Errorf("parsing redirects YAML: %w", err)
+	}
+
+	for i, r := range redirects {
+		if r.From == "" {
+			return fmt.Errorf("redirect %d: empty 'from' path", i)
+		}
+		if r.To == "" {
+			return fmt.Errorf("redirect %d: empty 'to' path", i)
+		}
+		if r.Code == 0 {
+			r.Code = 301
+		}
+		if r.Code < 300 || r.Code > 399 {
+			return fmt.Errorf("redirect %d: code %d not in 300-399 range", i, r.Code)
+		}
+		if _, exists := store.Redirects[r.From]; exists {
+			return fmt.Errorf("redirect %d: duplicate 'from' path %q", i, r.From)
+		}
+		store.Redirects[r.From] = r
+	}
+
 	return nil
 }
 

--- a/internal/content/loader_test.go
+++ b/internal/content/loader_test.go
@@ -440,6 +440,124 @@ Content.
 	}
 }
 
+func TestLoadFromDir_Redirects(t *testing.T) {
+	dir := t.TempDir()
+	redirectsYAML := `- from: /old-post
+  to: /blog/new-post
+  code: 302
+- from: /index
+  to: /
+  code: 301
+`
+	if err := os.WriteFile(filepath.Join(dir, "_redirects.yaml"), []byte(redirectsYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+
+	if len(store.Redirects) != 2 {
+		t.Fatalf("expected 2 redirects, got %d", len(store.Redirects))
+	}
+
+	r, ok := store.Redirects["/old-post"]
+	if !ok {
+		t.Fatal("missing redirect for /old-post")
+	}
+	if r.To != "/blog/new-post" {
+		t.Errorf("expected to=/blog/new-post, got %q", r.To)
+	}
+	if r.Code != 302 {
+		t.Errorf("expected code=302, got %d", r.Code)
+	}
+
+	r2, ok := store.Redirects["/index"]
+	if !ok {
+		t.Fatal("missing redirect for /index")
+	}
+	if r2.To != "/" {
+		t.Errorf("expected to=/, got %q", r2.To)
+	}
+}
+
+func TestLoadFromDir_RedirectsDefaultCode(t *testing.T) {
+	dir := t.TempDir()
+	redirectsYAML := `- from: /old
+  to: /new
+`
+	if err := os.WriteFile(filepath.Join(dir, "_redirects.yaml"), []byte(redirectsYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+
+	r, ok := store.Redirects["/old"]
+	if !ok {
+		t.Fatal("missing redirect for /old")
+	}
+	if r.Code != 301 {
+		t.Errorf("expected default code=301, got %d", r.Code)
+	}
+}
+
+func TestLoadFromDir_RedirectsMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	store, err := LoadFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadFromDir: %v", err)
+	}
+
+	if len(store.Redirects) != 0 {
+		t.Errorf("expected 0 redirects, got %d", len(store.Redirects))
+	}
+}
+
+func TestLoadFromDir_RedirectsValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "empty from",
+			yaml: "- from: \"\"\n  to: /new\n",
+		},
+		{
+			name: "empty to",
+			yaml: "- from: /old\n  to: \"\"\n",
+		},
+		{
+			name: "code 200",
+			yaml: "- from: /old\n  to: /new\n  code: 200\n",
+		},
+		{
+			name: "code 500",
+			yaml: "- from: /old\n  to: /new\n  code: 500\n",
+		},
+		{
+			name: "duplicate from",
+			yaml: "- from: /old\n  to: /a\n- from: /old\n  to: /b\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "_redirects.yaml"), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadFromDir(dir)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
 func TestStripCodeBlocks(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/content/sync.go
+++ b/internal/content/sync.go
@@ -94,6 +94,7 @@ func StartBackgroundSync(ctx context.Context, cfg SyncConfig, store *AtomicStore
 			slog.Info("content reloaded",
 				"posts", len(cs.Posts),
 				"projects", len(cs.Projects),
+				"redirects", len(cs.Redirects),
 			)
 		}
 	}

--- a/internal/content/types.go
+++ b/internal/content/types.go
@@ -152,6 +152,12 @@ func FormatDateRange(start ResumeDate, end *ResumeDate) string {
 	return s + " – " + end.FormatDate()
 }
 
+type Redirect struct {
+	From string `yaml:"from"`
+	To   string `yaml:"to"`
+	Code int    `yaml:"code"`
+}
+
 type ContentStore struct {
 	Posts       []BlogPost
 	PostsBySlug map[string]*BlogPost
@@ -161,6 +167,8 @@ type ContentStore struct {
 	ProjectsBySlug map[string]*Project
 
 	Resume *Resume
+
+	Redirects map[string]Redirect
 }
 
 // RelatedPosts returns up to `limit` posts related to the given slug,

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/willfindlay/williamfindlaycom/internal/content"
 )
 
 func logging(next http.Handler) http.Handler {
@@ -26,6 +28,18 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self' https://giscus.app; style-src 'self' 'unsafe-inline' https://giscus.app; img-src 'self' data: https:; frame-src https://giscus.app")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func redirects(store *content.AtomicStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if cs := store.Load(); cs != nil {
+			if redir, ok := cs.Redirects[r.URL.Path]; ok {
+				http.Redirect(w, r, redir.To, redir.Code)
+				return
+			}
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -22,9 +22,6 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /feed.json", s.deps.JSONFeed())
 	mux.HandleFunc("GET /sitemap.xml", s.deps.Sitemap())
 	mux.HandleFunc("GET /robots.txt", s.deps.Robots())
-	mux.HandleFunc("GET /index", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/", http.StatusMovedPermanently)
-	})
 
 	mux.HandleFunc("GET "+s.cssBundlePath, s.serveCSSBundle)
 
@@ -38,6 +35,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /", s.deps.Home())
 
 	var h http.Handler = mux
+	h = redirects(s.store, h)
 	h = securityHeaders(h)
 	h = logging(h)
 	return h

--- a/internal/server/routes_test.go
+++ b/internal/server/routes_test.go
@@ -63,6 +63,14 @@ More content.
 		t.Fatal(err)
 	}
 
+	redirectsYAML := `- from: /old-post
+  to: /blog/test-post
+  code: 301
+`
+	if err := os.WriteFile(filepath.Join(contentDir, "_redirects.yaml"), []byte(redirectsYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	store := content.NewAtomicStore()
 	cs, err := content.LoadFromDir(contentDir)
 	if err != nil {
@@ -491,6 +499,32 @@ func TestRoutes_Feed(t *testing.T) {
 	body := readBody(t, resp)
 	if !strings.Contains(body, "<feed") {
 		t.Error("expected Atom feed element in body")
+	}
+}
+
+func TestRoutes_Redirect(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Get(ts.URL + "/old-post")
+	if err != nil {
+		t.Fatalf("GET /old-post: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Errorf("expected 301, got %d", resp.StatusCode)
+	}
+
+	loc := resp.Header.Get("Location")
+	if loc != "/blog/test-post" {
+		t.Errorf("expected Location /blog/test-post, got %q", loc)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) Run() error {
 		return fmt.Errorf("initial content load: %w", err)
 	}
 	s.store.Store(cs)
-	slog.Info("content loaded", "posts", len(cs.Posts), "projects", len(cs.Projects))
+	slog.Info("content loaded", "posts", len(cs.Posts), "projects", len(cs.Projects), "redirects", len(cs.Redirects))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
Adds a redirect map to the content pipeline. The server reads a `_redirects.yaml` file from the content repo root during `LoadFromDir`, parses it into a `map[string]Redirect` on the `ContentStore`, and serves matching paths through a new `redirects` middleware that runs before `securityHeaders` in the handler chain. Each entry specifies `from`, `to`, and an optional `code` (defaults to 301). Validation rejects empty paths, out-of-range status codes, and duplicate `from` entries.

The hardcoded `/index` -> `/` redirect in `routes.go` is removed since it can now live in the content repo's `_redirects.yaml` instead.

Tests cover round-trip loading, default status codes, missing file graceful handling, validation error cases, and an integration test (`TestRoutes_Redirect`) that verifies the middleware returns the correct status and `Location` header.